### PR TITLE
Удаление скоупа на чтение email из twitch аутентификации

### DIFF
--- a/Backend/Interview.Backend/Auth/ServiceCollectionExt.cs
+++ b/Backend/Interview.Backend/Auth/ServiceCollectionExt.cs
@@ -47,6 +47,7 @@ public static class ServiceCollectionExt
                     var upsertUser = await userService.UpsertByTwitchIdentityAsync(user);
                     context.Principal!.EnrichRolesWithId(upsertUser);
                 };
+                options.Scope.Clear();
             });
 
         self.AddAuthorization(options =>


### PR DESCRIPTION
Теперь окно аутентификации twitch не говорит пользователю о том, что мы получаем его email.