### PR TITLE
Backend, UserController - Admins route

### DIFF
--- a/Backend/Interview.Backend/Users/UserController.cs
+++ b/Backend/Interview.Backend/Users/UserController.cs
@@ -62,6 +62,19 @@ public class UserController : ControllerBase
         return _userService.FindByRoleAsync(pageRequest.PageNumber, pageRequest.PageSize, role, HttpContext.RequestAborted);
     }
 
+    [Authorize(policy: GulagSecurePolicy.User)]
+    [HttpGet("admins")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(IPagedList<UserDetail>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(MessageResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(MessageResponse), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(MessageResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(MessageResponse), StatusCodes.Status500InternalServerError)]
+    public Task<IPagedList<UserDetail>> FindAdmins([FromQuery] PageRequest pageRequest)
+    {
+        return _userService.FindByRoleAsync(pageRequest.PageNumber, pageRequest.PageSize, RoleNameType.Admin, HttpContext.RequestAborted);
+    }
+
     [Authorize]
     [HttpGet("self")]
     [Produces("application/json")]


### PR DESCRIPTION
Обычному пользователю нужно знать id админов. Например, для определения того, что реакция лайка пришла от админа (внутри реакции есть только userId). Использовать `role/{role}` нельзя, т. к. он закрыт для обычных пользователей.