### PR TITLE
Backend, RoomChangeEntityProcessor - Send room status to ws

### DIFF
--- a/Backend/Interview.DependencyInjection/ServiceCollectionExt.cs
+++ b/Backend/Interview.DependencyInjection/ServiceCollectionExt.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExt
         self.AddSingleton<IChangeEntityProcessor, QuestionChangeEntityProcessor>();
         self.AddSingleton<IChangeEntityProcessor, RoomQuestionChangeEntityProcessor>();
         self.AddSingleton<IChangeEntityProcessor, RoomConfigurationChangeEntityProcessor>();
+        self.AddSingleton<IChangeEntityProcessor, RoomChangeEntityProcessor>();
 
         self.AddSingleton<IConnectUserSource, ConnectUserSource>();
         self.AddSingleton<IRoomEventSerializer, JsonRoomEventSerializer>();

--- a/Backend/Interview.Domain/Events/ChangeEntityProcessors/RoomChangeEntityProcessor.cs
+++ b/Backend/Interview.Domain/Events/ChangeEntityProcessors/RoomChangeEntityProcessor.cs
@@ -1,0 +1,61 @@
+using Interview.Domain.Events.Events;
+using Interview.Domain.Repository;
+using Interview.Domain.RoomConfigurations;
+using Interview.Domain.RoomQuestions;
+using Interview.Domain.Rooms;
+
+namespace Interview.Domain.Events.ChangeEntityProcessors
+{
+    public class RoomChangeEntityProcessor : IChangeEntityProcessor
+    {
+        private readonly IRoomEventDispatcher _eventDispatcher;
+
+        public RoomChangeEntityProcessor(IRoomEventDispatcher eventDispatcher)
+        {
+            _eventDispatcher = eventDispatcher;
+        }
+
+        public ValueTask ProcessAddedAsync(IReadOnlyCollection<Entity> entities, CancellationToken cancellationToken)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public async ValueTask ProcessModifiedAsync(IReadOnlyCollection<(Entity Original, Entity Current)> entities, CancellationToken cancellationToken)
+        {
+            foreach (var (originalEntity, currentEntity) in entities)
+            {
+                switch (originalEntity)
+                {
+                    case Room originalC when currentEntity is Room currentC:
+                        {
+                            var e = CreateEvent(currentC, originalC);
+                            if (e is not null)
+                            {
+                                await _eventDispatcher.WriteAsync(e, cancellationToken);
+                            }
+
+                            break;
+                        }
+                }
+            }
+        }
+
+        private static IRoomEvent? CreateEvent(Room current, Room? original)
+        {
+            if (original is null || original.Status != current.Status)
+            {
+                return new ChangeRoomStatusEvent(current.Id, current.Status.EnumValue.ToString());
+            }
+
+            return null;
+        }
+
+        public sealed class ChangeRoomStatusEvent : RoomEvent
+        {
+            public ChangeRoomStatusEvent(Guid roomId, string? value)
+                : base(roomId, EventType.ChangeRoomStatus, value)
+            {
+            }
+        }
+    }
+}

--- a/Backend/Interview.Domain/Events/EventType.cs
+++ b/Backend/Interview.Domain/Events/EventType.cs
@@ -64,4 +64,9 @@ public enum EventType
     /// The event is triggered when change code editor for room
     /// </summary>
     ChangeCodeEditor,
+
+    /// <summary>
+    /// The event is triggered when room status is changed
+    /// </summary>
+    ChangeRoomStatus,
 }


### PR DESCRIPTION
Отправка статуса комнаты по WebSocket.
Нужно для того, чтоб перебрасывать пользователей на страницу с отчётом при переводе статуса комнаты.