### PR TITLE
Feature/backend better grouping analytics

### DIFF
--- a/Backend/Interview.Infrastructure/Rooms/RoomRepository.cs
+++ b/Backend/Interview.Infrastructure/Rooms/RoomRepository.cs
@@ -79,6 +79,13 @@ public class RoomRepository : EfRepository<Room>, IRoomRepository
                         .ToList(),
                 })
                 .ToList();
+
+            var noReactions = viewers.Count == 0 && experts.Count == 0;
+            if (noReactions)
+            {
+                continue;
+            }
+
             summary.Questions.Add(new AnalyticsSummaryQuestion
             {
                 Id = question.Id,

--- a/Backend/Interview.Infrastructure/Rooms/RoomRepository.cs
+++ b/Backend/Interview.Infrastructure/Rooms/RoomRepository.cs
@@ -49,7 +49,7 @@ public class RoomRepository : EfRepository<Room>, IRoomRepository
 
             var viewers = reactionQuestions
                 .Where(e => participants[e.Sender!.Id] == RoomParticipantType.Viewer)
-                .GroupBy(e => e.Sender!.Id)
+                .GroupBy(e => participants[e.Sender!.Id])
                 .Select(e => new AnalyticsSummaryViewer
                 {
                     ReactionsSummary = e.GroupBy(t => (t.Reaction!.Id, t.Reaction.Type))

--- a/Backend/Interview.Test/Integrations/RoomServiceTest.cs
+++ b/Backend/Interview.Test/Integrations/RoomServiceTest.cs
@@ -536,21 +536,15 @@ public class RoomServiceTest
                                     Id = ReactionType.Like.Id,
                                     Type = ReactionType.Like.Name,
                                     Count = 1,
-                                }
-                            }
-                        },
-                        new()
-                        {
-                            ReactionsSummary = new List<Analytics.AnalyticsReactionSummary>
-                            {
+                                },
                                 new()
                                 {
                                     Id = ReactionType.Dislike.Id,
                                     Type = ReactionType.Dislike.Name,
                                     Count = 1,
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
                 new()
@@ -583,38 +577,12 @@ public class RoomServiceTest
                                 {
                                     Id = ReactionType.Dislike.Id,
                                     Type = ReactionType.Dislike.Name,
-                                    Count = 1,
-                                }
-                            }
-                        },
-                        new()
-                        {
-                            ReactionsSummary = new List<Analytics.AnalyticsReactionSummary>
-                            {
-                                new()
-                                {
-                                    Id = ReactionType.Dislike.Id,
-                                    Type = ReactionType.Dislike.Name,
-                                    Count = 1,
-                                }
+                                    Count = 2,
+                                },
                             }
                         }
                     },
-                },
-                new()
-                {
-                    Id = questions[2].Id,
-                    Value = questions[2].Value,
-                    Experts = new List<AnalyticsSummaryExpert>(),
-                    Viewers = new List<AnalyticsSummaryViewer>(),
-                },
-                new()
-                {
-                    Id = questions[3].Id,
-                    Value = questions[3].Value,
-                    Experts = new List<AnalyticsSummaryExpert>(),
-                    Viewers = new List<AnalyticsSummaryViewer>(),
-                },
+                }
             }
         };
 


### PR DESCRIPTION
Изменения:
1. **Зрители (`RoomParticipantType.Viewer`) группируются в одну запись.**
Было:
![b](https://github.com/VladislavPetyukevich/GulagGazRoom/assets/19724906/8d6ec786-a3ec-4747-a014-ea7a4032ba7e)
Стало:
![a](https://github.com/VladislavPetyukevich/GulagGazRoom/assets/19724906/faa62c12-8b40-4301-ab20-48867adc4089)

2. **Если на вопрос нет реакций, то он не возвращается.**
Было:
![b1](https://github.com/VladislavPetyukevich/GulagGazRoom/assets/19724906/c05fe4fa-9279-4f77-8711-1c26f68a047e)
Стало:
![a1](https://github.com/VladislavPetyukevich/GulagGazRoom/assets/19724906/c2eafd9b-42e7-427a-968b-c0f672cdc4cc)
